### PR TITLE
Add server stopping event

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -172,6 +172,13 @@ impl Client {
                 trace!("{}", msg);
                 let res: Result<(), InnerError> = async {
                     let text = msg.into_text().map_err(InnerError::IntoText)?;
+                    let text = if text == "Server stopping" {
+                        debug!("Websocket server is stopping");
+                        r#"{"update-type": "ServerStopping"}"#.to_string()
+                    } else {
+                        text
+                    };
+
                     let json = serde_json::from_str::<serde_json::Value>(&text)
                         .map_err(InnerError::DeserializeMessage)?;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -575,6 +575,8 @@ pub enum EventType {
         /// The new enabled state of Studio Mode.
         new_state: bool,
     },
+    /// WebSocket server is stopping.
+    ServerStopping,
     /// Fallback value for any unknown event type.
     #[serde(other)]
     Unknown,


### PR DESCRIPTION
OBS websocket sends a "ServerStopping" message when the websocket is closing.
Because this isn't in JSON it turns into a DeserializeMessage error.