### PR TITLE
Provide structures to define projector geometry

### DIFF
--- a/src/client/general.rs
+++ b/src/client/general.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use super::Client;
-use crate::requests::{KeyModifier, Projector, RequestType};
+use crate::requests::{KeyModifier, Projector, ProjectorInternal, QtGeometry, RequestType};
 use crate::responses;
 use crate::{Error, Result};
 
@@ -82,7 +82,12 @@ impl<'a> General<'a> {
     /// Open a projector window or create a projector on a monitor. Requires OBS v24.0.4 or newer.
     pub async fn open_projector(&self, projector: Projector<'_>) -> Result<()> {
         self.client
-            .send_message(RequestType::OpenProjector(projector))
+            .send_message(RequestType::OpenProjector(ProjectorInternal {
+                ty: projector.ty,
+                monitor: projector.monitor,
+                geometry: projector.geometry.map(QtGeometry::serialize).as_deref(),
+                name: projector.name,
+            }))
             .await
     }
 

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-integration")]
 
 use anyhow::Result;
-use obws::requests::{Projector, ProjectorType};
+use obws::requests::{Projector, ProjectorType, QtGeometry, QtRect};
 use serde_json::json;
 
 mod common;
@@ -31,6 +31,12 @@ async fn main() -> Result<()> {
     client
         .open_projector(Projector {
             ty: Some(ProjectorType::Multiview),
+            geometry: Some(&QtGeometry::new(QtRect {
+                left: 100,
+                top: 100,
+                right: 300,
+                bottom: 300,
+            })),
             ..Default::default()
         })
         .await?;


### PR DESCRIPTION
This adds a typed version of the Qt geometry instead of a `&str` as parameter for `open_projector` so that the users don't have to figure out and implement the geometry details themselves.

Resolves #9.