### PR TITLE
Handle authentication error messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,6 @@ pub enum Error {
         /// Optional message to provide additional details about the error.
         message: Option<String>,
     },
-    /// The obs-websocket API requires authentication but no password was given.
-    #[error("authentication required but no password provided")]
-    NoPassword,
     /// Unknown flags were found while trying to parse bitflags.
     #[error("value {0} contains unknown flags")]
     UnknownFlags(u8),


### PR DESCRIPTION
The authentication failed and missing authentication were not handled on
the handshake, they would instead return a failed deserializing message.

![image](https://user-images.githubusercontent.com/5977687/179647628-11d5bc2d-e5f1-4723-ab57-befc44713dee.png)
