### PR TITLE
Add timeout for first handshake message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_with = "2.0.0"
 sha2 = "0.10.2"
 thiserror = "1.0.31"
 time = "0.3.11"
-tokio = { version = "1.19.2", features = ["net", "rt", "sync"] }
+tokio = { version = "1.19.2", features = ["net", "rt", "sync", "time"] }
 tokio-tungstenite = "0.17.1"
 tracing = "0.1.35"
 

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use tokio::{
     sync::{oneshot, Mutex},
-    time::{timeout, Duration},
+    time::{self, Duration},
 };
 pub use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::Message;
@@ -159,7 +159,7 @@ pub(super) async fn handshake(
         serde_json::from_str::<ServerMessage>(&message).map_err(HandshakeError::DeserializeMessage)
     }
 
-    let server_message = timeout(Duration::from_secs(5), read_message(read))
+    let server_message = time::timeout(Duration::from_secs(5), read_message(read))
         .await
         .map_err(|_| HandshakeError::NoHello)?;
 


### PR DESCRIPTION
When connecting to obs-websocket 4.x, the connection gets accepted
but the handshake keeps waiting for a message from the server.

closes #24 