### PR TITLE
Make Scene response struct compatible with Scenes + SceneItems API

### DIFF
--- a/src/responses/scenes.rs
+++ b/src/responses/scenes.rs
@@ -23,12 +23,24 @@ pub struct Scenes {
 /// Response value for [`crate::client::Scenes::list`] as part of [`Scenes`].
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Scene {
+    /// UUID of the scene.
+    #[serde(rename = "sceneUuid")]
+    pub uuid: Uuid,
     /// Name of the scene.
     #[serde(rename = "sceneName")]
     pub name: String,
     /// Positional index in the list of scenes.
     #[serde(rename = "sceneIndex")]
     pub index: usize,
+}
+
+impl From<Scene> for SceneId {
+    fn from(scene: Scene) -> Self {
+        Self {
+            name: scene.name,
+            uuid: scene.uuid
+        }
+    }
 }
 
 /// Response value for [`crate::client::Scenes::get_group_list`].


### PR DESCRIPTION
The `GetSceneList` request for `obs-websocket` [includes a UUID for each scene in the list](https://github.com/obsproject/obs-websocket/blob/master/src/utils/Obs_ArrayHelper.cpp#L99), but the [response struct `Scene`](https://docs.rs/obws/latest/obws/responses/scenes/struct.Scene.html) used in the `scenes` field of the return type for the [analogous API function](https://docs.rs/obws/latest/obws/client/struct.Scenes.html#method.list) does not de-serialize it. 

As a result, most of the API made available through [`Scenes`](https://docs.rs/obws/latest/obws/client/struct.Scenes.html) and [`SceneItems`](https://docs.rs/obws/latest/obws/client/struct.SceneItems.html) is rendered inaccessible for any scene that isn't currently the Preview or Program scene ( each of which are made available as `SceneId` and so are usable with said APIs ).

This addition adds a field for the `sceneUuid` to be de-serialized to, in addition to adding a `From<Scene>` implementation for `SceneId`  that simply drops the `index` field of `Scene`. This makes it so that all scenes can be used with the `Scenes` and `SceneItems` APIs after calling `.into()`

Please let me know if I've missed anything and I'd be more than happy to make corrections.