### PR TITLE
chore(deps): bump tokio-tungstenite to v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.10.8"
 thiserror = "1.0.59"
 time = "0.3.36"
 tokio = { version = "1.37.0", features = ["net", "rt", "sync", "time"] }
-tokio-tungstenite = "0.22.0"
+tokio-tungstenite = "0.23.0"
 tracing = "0.1.40"
 uuid = { version = "1.8.0", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.10.8"
 thiserror = "1.0.59"
 time = "0.3.36"
 tokio = { version = "1.37.0", features = ["net", "rt", "sync", "time"] }
-tokio-tungstenite = "0.21.0"
+tokio-tungstenite = "0.22.0"
 tracing = "0.1.40"
 uuid = { version = "1.8.0", features = ["serde"] }
 


### PR DESCRIPTION
SSIA.

My build failed for the following reasons:
```
Command failed: cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --package tokio-tungstenite@0.21.0 --precise 0.22.0
    Updating crates.io index
error: failed to select a version for the requirement `tokio-tungstenite = "^0.21.0"`
candidate versions found which didn't match: 0.22.0
location searched: crates.io index
required by package `obws v0.12.0`
    ... which satisfies dependency `obws = "^0.12.0"` (locked to 0.12.0) of package `obs-spotify-bridge v0.1.0 (/tmp/renovate/repos/github/yanorei32/obs-spotify-bridge)`
perhaps a crate was updated and forgotten to be re-vendored?
```

https://github.com/yanorei32/obs-spotify-bridge/pull/219#issuecomment-2143635349

I've verified that this branch builds and tests pass.