### PR TITLE
fix: VlcSource loop_

### DIFF
--- a/src/requests/custom/source_settings.rs
+++ b/src/requests/custom/source_settings.rs
@@ -550,7 +550,7 @@ impl Default for Font<'_> {
 #[cfg_attr(feature = "builder", derive(bon::Builder))]
 pub struct VlcSource<'a> {
     /// Loop play-list.
-    #[serde(rename = "bool")]
+    #[serde(rename = "loop")]
     pub loop_: bool,
     /// Shuffle play-list.
     pub shuffle: bool,


### PR DESCRIPTION
fixed loop_ member
I noticed what seemed to be a  typo where it was renamed to `bool`, so I went ahead and changed it to `loop`.

Until this change was made, the VLC source looped regardless of the value of `loop_`, but as a result of the fix, the value of `loop_` is now functioning correctly.